### PR TITLE
Normalize cache bypass response

### DIFF
--- a/lib/req_client.ex
+++ b/lib/req_client.ex
@@ -6,7 +6,7 @@ defmodule Storyblok.ReqClient do
     opts =
       opts
       |> Keyword.put(:params, query)
-      |> Keyword.put_new(:follow_redirects, true)
+      |> Keyword.put_new(:redirect, true)
 
     case Req.get(url, opts) do
       {:ok, response} ->

--- a/lib/storyblok.ex
+++ b/lib/storyblok.ex
@@ -15,10 +15,6 @@ defmodule Storyblok do
     operation = Operation.put_token(operation, token)
     cache = Application.get_env(:storyblok, :cache, false) && Operation.cache?(operation)
 
-    dbg(operation)
-    dbg(cache)
-    dbg(token)
-
     request_fun = fn ->
       Client.execute(
         Operation.url(operation),
@@ -48,7 +44,14 @@ defmodule Storyblok do
         {:ok, data}
       end
     else
-      request_fun.()
+      with {:ok, %{status: 200} = response} <- request_fun.() do
+        data = %{
+          "headers" => Enum.into(response.headers, %{}),
+          "data" => response.body
+        }
+
+        {:ok, data}
+      end
     end
   end
 end

--- a/lib/storyblok.ex
+++ b/lib/storyblok.ex
@@ -15,6 +15,10 @@ defmodule Storyblok do
     operation = Operation.put_token(operation, token)
     cache = Application.get_env(:storyblok, :cache, false) && Operation.cache?(operation)
 
+    dbg(operation)
+    dbg(cache)
+    dbg(token)
+
     request_fun = fn ->
       Client.execute(
         Operation.url(operation),


### PR DESCRIPTION
Normalizes the response payload when skipping cache(in the case of draft content for example) and fixes a runtime warning.